### PR TITLE
fix `put_finalize`, must return `location` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ The crate has not been thoroughly battle tested in contested production environm
 
 `container-registry` includes a bare-bones installable binary that exposes most of its features from the command line. It is automatically built if the `bin` features is enabled:
 
-```
+```sh
 cargo install container-registry --features bin
 ```


### PR DESCRIPTION
Required to make `oci_distribution` work, which does check the header ( https://github.com/krustlet/oci-distribution/blob/93510ce53108f4db6c250f1f4f9b8f3c6df85a27/src/client.rs#L959 )  

https://github.com/opencontainers/distribution-spec/blob/v1.0.1/spec.md#endpoints

```
The closing PUT request MUST include the <digest> of the whole blob (not the final chunk) as a query parameter.

The response to a successful closing of the session MUST be 201 Created, and MUST contain the following header:
```