### PR TITLE
Anonymous policy should be able to access the registry.

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -257,10 +257,10 @@ where
     A: AuthProvider,
 {
     async fn check_credentials(&self, unverified: &Unverified) -> Option<ValidCredentials> {
-        Some(ValidCredentials::new(match unverified {
-            Unverified::NoCredentials => AnonCreds::Anonymous,
-            _other => AnonCreds::Valid(self.inner.check_credentials(unverified).await?),
-        }))
+        match unverified {
+            Unverified::NoCredentials => Some(ValidCredentials::new(AnonCreds::Anonymous)),
+            _other => self.inner.check_credentials(unverified).await,
+        }
     }
 
     async fn image_permissions(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,13 +305,13 @@ async fn index_v2(
 ) -> Response<Body> {
     let realm = &registry.realm;
 
-    // TODO: This code duplicates some of the extraction logic of `Unverified` -- and how does it work for anonymous access?
-    if !unverified.is_no_credentials()
-        && registry
-            .auth_provider
-            .check_credentials(&unverified)
-            .await
-            .is_some()
+    // Both anonymous and named users should be verified to be able to get index. Restricted access
+    // is handled identically for both via the rules set within the registry constructor.
+    if registry
+        .auth_provider
+        .check_credentials(&unverified)
+        .await
+        .is_some()
     {
         return Response::builder()
             .status(StatusCode::OK)


### PR DESCRIPTION
The anonymous policy used to be always rejected within the version endpoint (the index endpoint). As a consequence, anonymous policy users would fail to use the registry, even if it was configured to be all-permissive. In this PR:

1. Fix up the handling of permissions handling within the index endpoint
2. Add tests for an anonymous client using the index endpoint