### PR TITLE
Update quick-test.sh

### DIFF
--- a/quick-test.sh
+++ b/quick-test.sh
@@ -1,6 +1,32 @@
-#!/bin/sh
+#!/bin/bash
+set -x
+run_podman_tests() {
+    if ! command -v podman &> /dev/null; then
+        echo "Podman is not installed"
+        return 1
+    fi
 
-# TODO: This file is leftover from `rockslide` and probably needs to be adapted.
+    echo "Running tests with Podman..."
+    podman login --tls-verify=false --username devuser --password devpw http://${REGISTRY_ADDR}
+    podman rmi hello-world
+    podman pull hello-world
+    podman tag hello-world ${REGISTRY_ADDR}/testing/hello:prod
+    podman push --tls-verify=false ${REGISTRY_ADDR}/testing/hello:prod
+}
+
+run_docker_tests() {
+    if ! command -v docker &> /dev/null; then
+        echo "Docker is not installed"
+        return 1
+    fi
+
+    echo "Running tests with Docker..."
+    docker login --username devuser --password devpw http://${REGISTRY_ADDR}
+    docker rmi hello-world
+    docker pull hello-world
+    docker tag hello-world ${REGISTRY_ADDR}/testing/hello:prod
+    docker push ${REGISTRY_ADDR}/testing/hello:prod
+}
 
 export REGISTRY_ADDR=127.0.0.1:3000
 
@@ -10,11 +36,20 @@ fi
 
 echo "registry: ${REGISTRY_ADDR}"
 
-podman login --tls-verify=false --username devuser --password devpw http://${REGISTRY_ADDR}
-podman pull crccheck/hello-world
-podman tag crccheck/hello-world ${REGISTRY_ADDR}/testing/hello:prod
-podman push --tls-verify=false ${REGISTRY_ADDR}/testing/hello:prod
+cargo run --features="bin" &
+CARGO_PID=$!
 
 sleep 2
 
+run_podman_tests
+
+sleep 2
+
+run_docker_tests
+
+sleep 2
+
+echo "Testing with curl..."
 curl -v http://${REGISTRY_ADDR}/testing/hello
+
+kill $CARGO_PID


### PR DESCRIPTION
Example run:

```
leon@debian:~/container_registry-rs$ ./quick-test.sh 
+ export REGISTRY_ADDR=127.0.0.1:3000
+ REGISTRY_ADDR=127.0.0.1:3000
+ '[' x == xtrue ']'
+ echo 'registry: 127.0.0.1:3000'
registry: 127.0.0.1:3000
+ CARGO_PID=223744
+ sleep 2
+ cargo run --features=bin
warning: variant `Valid` is never constructed
   --> src/auth.rs:251:5
    |
247 | enum AnonCreds {
    |      --------- variant in this enum
...
251 |     Valid(ValidCredentials),
    |     ^^^^^
    |
    = note: `AnonCreds` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
    = note: `#[warn(dead_code)]` on by default

warning: `container-registry` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/container-registry`
2025-01-18T12:43:28.248001Z  INFO container_registry: using temporary storage path=/tmp/container_registry_test.cLB7Mkbvjvsi
2025-01-18T12:43:28.248036Z  WARN container_registry: no password set, allowing access with any credential
2025-01-18T12:43:28.250886Z  INFO container_registry: bound, starting to serve addr=127.0.0.1:3000
+ run_podman_tests
+ command -v podman
+ echo 'Running tests with Podman...'
Running tests with Podman...
+ podman login --tls-verify=false --username devuser --password devpw http://127.0.0.1:3000
Login Succeeded!
+ podman rmi hello-world
Untagged: docker.io/library/hello-world:latest
+ podman pull hello-world
Resolved "hello-world" as an alias (/etc/containers/registries.conf.d/shortnames.conf)
Trying to pull docker.io/library/hello-world:latest...
Getting image source signatures
Copying blob 478afc919002 skipped: already exists  
Copying config ee301c921b done  
Writing manifest to image destination
Storing signatures
ee301c921b8aadc002973b2e0c3da17d701dcd994b606769a7e6eaa100b81d44
+ podman tag hello-world 127.0.0.1:3000/testing/hello:prod
+ podman push --tls-verify=false 127.0.0.1:3000/testing/hello:prod
Getting image source signatures
Copying blob 12660636fe55 done  
2025-01-18T12:43:35.221223Z  INFO container_registry: new image uploaded upload=5671f9c4-903b-4409-ae5b-b0582d80ff05 digest=sha256:4289bbabf4edb859a287166c7f9166c75e1b08ded6bf5b46f73914f54c7051e1
Copying config ee301c921b done  
2025-01-18T12:43:35.223648Z  INFO container_registry: new image uploaded upload=84ced3f7-b247-4618-89c3-e4ed45888e56 digest=sha256:ee301c921b8aadc002973b2e0c3da17d701dcd994b606769a7e6eaa100b81d44
Writing manifest to image destination
2025-01-18T12:43:35.224961Z  INFO container_registry: new manifest received manifest_reference=testing/hello:prod digest=1198a4b7936ff136f41d6aecaaa57a5b74c253a97c47e434e2370e288d2c0ac0
2025-01-18T12:43:35.224984Z  INFO container_registry: new manifest uploaded manifest_reference=testing/hello:prod
Storing signatures
+ sleep 2
+ run_docker_tests
+ command -v docker
+ echo 'Running tests with Docker...'
Running tests with Docker...
+ docker login --username devuser --password devpw http://127.0.0.1:3000
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Error response from daemon: Get "http://127.0.0.1:3000/v2/": dial tcp 127.0.0.1:3000: connect: connection refused
+ docker rmi hello-world
Untagged: hello-world:latest
Untagged: hello-world@sha256:1b7a37f2a0e26e55ba2916e0c53bfbe60d9bd43e390e31aacd25cb3581ed74e6
+ docker pull hello-world
Using default tag: latest
latest: Pulling from library/hello-world
Digest: sha256:1b7a37f2a0e26e55ba2916e0c53bfbe60d9bd43e390e31aacd25cb3581ed74e6
Status: Downloaded newer image for hello-world:latest
docker.io/library/hello-world:latest
+ docker tag hello-world 127.0.0.1:3000/testing/hello:prod
+ docker push 127.0.0.1:3000/testing/hello:prod
The push refers to repository [127.0.0.1:3000/testing/hello]
Get "http://127.0.0.1:3000/v2/": dial tcp 127.0.0.1:3000: connect: connection refused
+ sleep 2
+ echo 'Testing with curl...'
Testing with curl...
+ curl -v http://127.0.0.1:3000/testing/hello
*   Trying 127.0.0.1:3000...
* Connected to 127.0.0.1 (127.0.0.1) port 3000 (#0)
> GET /testing/hello HTTP/1.1
> Host: 127.0.0.1:3000
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< content-length: 0
< date: Sat, 18 Jan 2025 12:43:41 GMT
< 
* Connection #0 to host 127.0.0.1 left intact
+ kill 223744
```

I'm not sure why it's not working with Docker. I've added the `insecure-registries` config and it seems like it should work. I'll investigate this, but if anyone has any idea as to why it doesn't work, let me know.